### PR TITLE
Jenkins插件命令拼装逻辑修正

### DIFF
--- a/plugins/jenkins_plugin/src/main/java/io/jenkins/plugins/StartClient.java
+++ b/plugins/jenkins_plugin/src/main/java/io/jenkins/plugins/StartClient.java
@@ -40,7 +40,7 @@ public class StartClient {
                     + " --branch " + branchName
                     + " --language " + languageType;
 
-            if (null != isTotal && !isTotal.isEmpty() {
+            if (null != isTotal && !isTotal.isEmpty()) {
                 startCommand += isTotal;
             }
 

--- a/plugins/jenkins_plugin/src/main/java/io/jenkins/plugins/StartClient.java
+++ b/plugins/jenkins_plugin/src/main/java/io/jenkins/plugins/StartClient.java
@@ -38,8 +38,11 @@ public class StartClient {
                     + " --team-name " + projectName
                     + " -s " + localCodePath
                     + " --branch " + branchName
-                    + " --language " + languageType
-                    + isTotal;
+                    + " --language " + languageType;
+
+            if (null != isTotal && !isTotal.isEmpty() {
+                startCommand += isTotal;
+            }
 
             Process p = Runtime.getRuntime().exec(
                     startCommand,


### PR DESCRIPTION
修复当jenkins任务中没有勾选全量扫描时，total=null导致isTotal=null，进而导致拼装命令时languageType后错误地拼上'null'的问题；