### PR TITLE
:fire:删除Dockerfile中文注释

### DIFF
--- a/server/dockerconfs/Dockerfile-common-mirror
+++ b/server/dockerconfs/Dockerfile-common-mirror
@@ -1,4 +1,3 @@
-# 如果需要在ARM架构上运行，可以将第一个 FROM指令 进行注释，然后将第二个 FROM指令 取消注释
 FROM python:3.7.12-slim
 # For ARM
 # FROM arm64v8/python:3.7.12-slim

--- a/server/dockerconfs/Dockerfile-common-normal
+++ b/server/dockerconfs/Dockerfile-common-normal
@@ -1,4 +1,3 @@
-# 如果需要在ARM架构上运行，可以将第一个 FROM指令 进行注释，然后将第二个 FROM指令 取消注释
 FROM python:3.7.12-slim
 # For ARM
 # FROM arm64v8/python:3.7.12-slim  


### PR DESCRIPTION
删除dockerfile中文注释；部分docker-compose版本（比如1.26.0）读取包含中文的dockerfile时会因编码问题导致读取不完整