### PR TITLE
:pushpin:锁定importlib-metadata版本

### DIFF
--- a/server/configs/requirements.txt
+++ b/server/configs/requirements.txt
@@ -28,6 +28,7 @@ drf-yasg==1.17.0
 
 # for celery
 celery==5.2.3
+importlib-metadata==4.13.0
 django-celery-results==2.4.0
 redis==4.1.1
 celery-redbeat==2.0.0

--- a/server/projects/analysis/requirements.txt
+++ b/server/projects/analysis/requirements.txt
@@ -10,6 +10,7 @@ pymysql==1.0.2
 
 # for celery
 celery==5.2.3
+importlib-metadata==4.13.0
 redis==4.1.1
 
 # for password

--- a/server/projects/file/requirements.txt
+++ b/server/projects/file/requirements.txt
@@ -13,6 +13,7 @@ djangorestframework==3.11.2
 
 # for celery
 celery==5.2.3
+importlib-metadata==4.13.0
 redis==4.1.1
 
 # for exception log

--- a/server/projects/main/requirements.txt
+++ b/server/projects/main/requirements.txt
@@ -15,6 +15,7 @@ markupsafe==2.0.1
 
 # for celery
 celery==5.2.3
+importlib-metadata==4.13.0
 django-celery-results==2.4.0
 redis==4.1.1
 celery-redbeat==2.0.0


### PR DESCRIPTION
锁定importlib-metadata版本，避免celery模块加载失败