### PR TITLE
fix:docker build

### DIFF
--- a/server/dockerconfs/Dockerfile-nginx-mirror
+++ b/server/dockerconfs/Dockerfile-nginx-mirror
@@ -1,8 +1,9 @@
 FROM nginx:1.13.7
 
 RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak && \
-    echo 'deb http://mirrors.tencent.com/debian/ stretch main' > /etc/apt/sources.list && \
-    echo 'deb http://mirrors.tencent.com/debian/ stretch-updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://mirrors.tencent.com/debian-archive/debian/ stretch main' > /etc/apt/sources.list && \
+    echo 'deb http://mirrors.tencent.com/debian-archive/debian-security/ stretch/updates main' >> /etc/apt/sources.list && \
     echo 'deb http://nginx.org/packages/mainline/debian/ stretch nginx' >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y unzip procps && rm /etc/nginx/conf.d/default.conf
+

--- a/server/projects/analysis/requirements.txt
+++ b/server/projects/analysis/requirements.txt
@@ -36,7 +36,7 @@ Pygments==2.8.1
 drf-yasg==1.17.0
 
 # for file upload and download
-urllib3==1.26.7
+urllib3==1.26.11
 
 django-filter==2.4.0
 

--- a/server/projects/main/requirements.txt
+++ b/server/projects/main/requirements.txt
@@ -41,7 +41,7 @@ rsa==4.7.2
 django-guardian==2.3.0
 
 # for file upload and download
-urllib3==1.26.7
+urllib3==1.26.11
 
 # for database import and export module
 django-import-export==2.5.0

--- a/server/projects/scmproxy/requirements.txt
+++ b/server/projects/scmproxy/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==1.26.7
+urllib3==1.26.11
 
 psutil==5.8.0
 


### PR DESCRIPTION
修复本地构建的一些问题
1、修改所有 requirements
urllib3==1.26.7 为 urllib3==1.26.11 可以构建成功
2、nginx镜像 debian 9 的地址更改了，debian-archive 可以构建成功