### PR TITLE
:art:完善Docker构建解决原基础镜像Debian-12.0与mariadb-10.6不兼容问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 ENV REDIS_PASSWD=tca2022
 ENV MYSQL_PASSWORD=TCA!@#2021


### PR DESCRIPTION
* 场景：
使用main分支代码进行打包镜像`TCA_IMAGE_BUILD=true ./quick_install.sh docker deploy`
时，执行报错
``` log
4273.2 + bash /tmp/mariadb_repo_setup --mariadb-server-version=mariadb-10.6
4273.2 # [error] Detected Debian but version (12.0) is not supported.
4273.2 # [error] # The MariaDB Repository only supports these distributions:
4273.2 #    * RHEL/Rocky 8 & 9 (rhel)
4273.2 #    * RHEL/CentOS 7 (rhel)
4273.2 #    * Ubuntu 18.04 LTS (bionic), 20.04 LTS (focal), and 22.04 LTS (jammy)
4273.2 #    * Debian 10 (buster), & 11 (bullseye)
4273.2 #    * SLES 12 & 15 (sles)
4273.2 # [error] # See https://mariadb.com/kb/en/mariadb/mariadb-package-repository-setup-and-usage/#platform-support
```
* 分析：
python:3.7-slim （Image hierarchy From debian:12-slim），而MariaDB-10.6不支持Debian-12 
基础镜像操作系统升级后导致兼容

* 解决：
更换Python基础镜像为**3.7-slim-bullseye**（Image hierarchy From  debian:11-slim）
重新运行脚本后执行成功。