### PR TITLE
:bug:修复挂载的代码目录owner不是root时，导致git blame异常

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -22,4 +22,7 @@ RUN pip3 install --no-cache-dir -U pip \
 
 COPY . .
 
+# 避免挂载的代码目录owner不是root时，导致git blame异常 - fatal: unsafe repository ('/xxx/xxx' is owned by someone else)
+RUN git config --global --add safe.directory '*'
+
 CMD [ "python3", "codepuppy.py", "localscan"]


### PR DESCRIPTION
:bug:修复挂载的代码目录owner不是root时，导致git blame异常 - fatal: unsafe repository ('/xxx/xxx' is owned by someone else)