### PR TITLE
:bug: 修复dockerfile缺少工具

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.12-slim
 
-ARG EXTRA_TOOLS="curl wget python3-dev git git-lfs vim-tiny gcc locales subversion telnet procps openssh-client"
+ARG EXTRA_TOOLS="curl wget python3-dev git git-lfs vim-tiny gcc locales subversion telnet procps openssh-client libreadline-dev"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends $EXTRA_TOOLS \
@@ -10,6 +10,7 @@ RUN apt-get update \
     && echo "LANG=zh_CN.UTF-8" > /etc/locale.conf \
     && locale-gen \
     && ln -sf /usr/share/zoneinfo/Asia/Hong_Kong /etc/localtime \
+    && cd /lib/x86_64-linux-gnu && ln -sf libreadline.so.8.1 libreadline.so.6 \
     && rm -rf /var/cache/apt/* /root/.cache
 
 WORKDIR /workspace/client


### PR DESCRIPTION
:bento: libreadline.so.6在lua场景分析的时候报错
![cf8ae2164dc77711384a02b997548be](https://github.com/Tencent/CodeAnalysis/assets/3351405/82f803bd-046a-4fc7-a5b9-025ccedc1c90)
![70b8c4a5d51ec21f4d5f9460f6973c7](https://github.com/Tencent/CodeAnalysis/assets/3351405/e37a5302-eea7-49a7-80fd-9c73e5dcf6c7)

https://askubuntu.com/questions/1168787/libreadline-so-6-issue-in-ubuntu-18-04

用tca-client 镜像启动lua分析，如果不解决这个问题，分析工具一定报错

通过这个修改，我自己生成一个镜像 docker pull zzzfwww/tca-client，用这个镜像就解决这个报错，修改如上 
