### PR TITLE
添加了'--ulimit nofile=10240:10240'

### DIFF
--- a/scripts/deploy/tca_docker.sh
+++ b/scripts/deploy/tca_docker.sh
@@ -42,7 +42,7 @@ function get_image() {
 function deploy_container() {
     LOG_INFO "Deploy tca container command:"
     set -x
-    docker run -it --env TCA_INIT_DATA=$TCA_INIT_DATA \
+    docker run -it --ulimit nofile=10240:10240 --env TCA_INIT_DATA=$TCA_INIT_DATA \
         --name $TCA_CONTAINER_NAME --publish 80:80 --publish 8000:8000 --publish 9001:9001 \
         -v $TCA_DOCKER_LOG_PATH:/var/log/tca/ \
         -v $TCA_DOCKER_DATA_PATH:/var/opt/tca/ \


### PR DESCRIPTION
docker部署过程中，会遇到报错“Error: The minimum number of file descriptors required to run this process is 10240 as per the "minfds" command-line argument or config file setting. The current environment will only allow you to open 10240 file descriptors. Either raise the number of usable file descriptors in your environment (see README.rst) or lower the minfds setting in the config file to allow the process to start.
For help, use /usr/local/bin/supervisord -h + ret=2
+ set +x
[2024/07/23 18:01:27] [ERROR]: Deploy tca docker failed”

解决办法：需要扩充docker ulimit数而不是系统的ulimit
在/CodeAnalysis/scripts/deploy/tca_docker.sh中添加代码"--ulimit nofile=10240:10240"
如图所示
<img width="873" alt="企业微信截图_1b6e1b00-d001-4e46-813a-7085930e3274" src="https://github.com/user-attachments/assets/5239df94-39fa-4263-9692-f2d0cfecb543">
