### PR TITLE
:art:工具配置仓库迁移到tca-tools-opensource/puppy-tools-config

### DIFF
--- a/client/config.ini
+++ b/client/config.ini
@@ -5,7 +5,7 @@
 [COMMON]
 ; [必填]工具配置库git地址
 ; 此处默认使用的是腾讯工蜂地址，也支持切换为github地址（github拉取工具较慢，不推荐切换）：https://github.com/TCATools/puppy-tools-config.git
-TOOL_CONFIG_URL=https://git.code.tencent.com/TCA/tca-tools/puppy-tools-config.git
+TOOL_CONFIG_URL=https://git.code.tencent.com/TCA/tca-tools/tca-tools-opensource/puppy-tools-config.git
 ; NOCA:hardcode-password([必填]scm加解密秘钥，工具代码库是开源代码库，任何人可以访问，该密钥可以公开，不存在泄露风险。)
 PASSWORD_KEY=a6x4c7esudcv396w
 ; [可选]日志级别,默认为info级别,设置为True则调整为debug级别


### PR DESCRIPTION
:art:工具配置仓库迁移到tca-tools-opensource/puppy-tools-config